### PR TITLE
Removal of Paralyzer from ability randomization to prevent softlocks

### DIFF
--- a/randomizer.py
+++ b/randomizer.py
@@ -390,7 +390,7 @@ class AbilityObject(NameMixin):
     ATTACK_SKILL = 2
     EXAMINE_SKILL = 3
 
-    BANNED_SKILLS = ['Head Cracker', 'Nue Stomp']
+    BANNED_SKILLS = ['Head Cracker', 'Nue Stomp', 'Paralyzer']
     LEVELUP_BANNED_SKILLS = ['Backhand']
 
     @property


### PR DESCRIPTION
Softlocks occur when enemies use Paralyzer, remove from ability randomization pool